### PR TITLE
Multiple frameworks support

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,16 +16,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Setup .NET
+    - name: Setup .NET 9
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 9.0.x 
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       working-directory: ./src/
       run: dotnet restore
     - name: Build
       working-directory: ./src/
       run: dotnet build --no-restore
-    - name: Test
+    - name: Test .NET 9.0
       working-directory: ./src/
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --framework net9.0 --no-build --verbosity normal
+    - name: Test .NET 8.0
+      working-directory: ./src/
+      run: dotnet test --framework net8.0 --no-build --verbosity normal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 All notable changes to this project since version 1.0.14 will be documented in this file.
 
+## [3.0.2] - 01.02.2025
+**Description:**
+Adding support for multiple .NETs.
+
+Now .NET 8 (LTS) and .NET 9 (latest) will be supported.
+
+Thanks @wbaldoumas and @tbolon for ideas for improvements!
+
 ## [3.0.1] - 19.01.2025
 **Description:**
 Line numbering starts now from 1 instead of 0.

--- a/src/CLI/CLI.csproj
+++ b/src/CLI/CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>CsharpToColouredHTML.Core</RootNamespace>
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/Swiftly1/CsharpToColouredHTML</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Swiftly1/CsharpToColouredHTML</RepositoryUrl>
     <PackageId>CsharpToColouredHTML.Core</PackageId>
-    <Version>3.0.1</Version>
+    <Version>3.0.2</Version>
     <Description>C# to HTML converter with syntax highlighting</Description>
     <PackageTags>c#;html;converter;syntax;highlighting</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Adding support for multiple .NETs.

Now .NET 8 (LTS) and .NET 9 (latest) will be supported.

The original idea: 
https://github.com/Swiftly1/CsharpToColouredHTML/issues/32
https://github.com/Swiftly1/CsharpToColouredHTML/pull/33 
