### PR TITLE
chore: DRY in CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,23 +16,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Setup .NET 9
+    - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 9.0.x 
-    - name: Setup .NET 8
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          8.0.x
+          9.0.x
     - name: Restore dependencies
       working-directory: ./src/
       run: dotnet restore
     - name: Build
       working-directory: ./src/
       run: dotnet build --no-restore
-    - name: Test .NET 9.0
+    - name: Test .NET
       working-directory: ./src/
-      run: dotnet test --framework net9.0 --no-build --verbosity normal
-    - name: Test .NET 8.0
-      working-directory: ./src/
-      run: dotnet test --framework net8.0 --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal


### PR DESCRIPTION
Small tweak to DRY up the GitHub workflow and slightly optimize it. 

You can specify multiple .NET versions for `actions/setup-dotnet@v3` and it will build and run tests against both versions without needing to repeat setup and test steps.

Example CI run [here](https://github.com/wbaldoumas/CsharpToColouredHTML/actions/runs/13092453816/job/36530705982#step:6:21) where you can see tests against both .NET 8 and .NET 9 in action.